### PR TITLE
Revert "DO NOT MERGE Disable overlays while installer is resumed"

### DIFF
--- a/src/com/android/packageinstaller/PackageInstallerActivity.java
+++ b/src/com/android/packageinstaller/PackageInstallerActivity.java
@@ -16,6 +16,7 @@
 */
 package com.android.packageinstaller;
 
+import android.app.Activity;
 import android.app.ActivityManagerNative;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -54,8 +55,6 @@ import android.widget.TabHost;
 import android.widget.TextView;
 import com.android.packageinstaller.permission.utils.Utils;
 
-import com.android.packageinstaller.permission.ui.OverlayTouchActivity;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -72,8 +71,7 @@ import java.io.OutputStream;
  * Based on the user response the package is then installed by launching InstallAppConfirm
  * sub activity. All state transitions are handled in this activity
  */
-public class PackageInstallerActivity extends OverlayTouchActivity implements OnCancelListener,
-        OnClickListener {
+public class PackageInstallerActivity extends Activity implements OnCancelListener, OnClickListener {
     private static final String TAG = "PackageInstaller";
 
     private static final int REQUEST_ENABLE_UNKNOWN_SOURCES = 1;
@@ -250,25 +248,6 @@ public class PackageInstallerActivity extends OverlayTouchActivity implements On
                     mOk.setOnClickListener(PackageInstallerActivity.this);
                 }
             });
-        }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-
-        if (mOk != null) {
-            mOk.setEnabled(mOkCanInstall);
-        }
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-
-        if (mOk != null) {
-            // Don't allow the install button to be clicked as there might be overlays
-            mOk.setEnabled(false);
         }
     }
 


### PR DESCRIPTION
If mOkCanInstall is false when onResume() is called, the button gets
disabled and never re-enabled. This fix is for branches that have
change I42c15d05dffc1f6db69c9f67148f7ceb6e8bd8ae ("Split layout for
confirm step.") which causes the button to be disabled and enabled
for different reasons. Here the button is constantly enabled and its
action changes depending on the value of mOkCanInstall. The attribute
filterTouchesWhenObscured should prevent tapjacking when overlays are
present, so revert this commit.

This reverts commit cec631f26e2cbd7c51fd7c28e05d379d6d0f86db.

REGRESSION-1262

Change-Id: I819aab95506672d291e07193b71f074292862754